### PR TITLE
Display commands grouped by module

### DIFF
--- a/_examples/cmd/env_info.go
+++ b/_examples/cmd/env_info.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"github.com/gookit/gcli"
-	"github.com/gookit/gcli/show"
 	"os"
 	"runtime"
+
+	"github.com/gookit/gcli"
+	"github.com/gookit/gcli/show"
 )
 
 // options for the command
@@ -19,7 +20,7 @@ var eiOpts = struct {
 // EnvInfoCommand
 func EnvInfoCommand() *gcli.Command {
 	cmd := gcli.Command{
-		Name:    "env",
+		Name:    "module:env",
 		Aliases: []string{"env-info", "ei"},
 		UseFor:  "collect project info by git info",
 

--- a/_examples/cmd/example.go
+++ b/_examples/cmd/example.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/gookit/color"
 	"github.com/gookit/gcli"
 )
@@ -31,7 +32,7 @@ var exampleOpts = struct {
 func ExampleCommand() *gcli.Command {
 	cmd := &gcli.Command{
 		Func:    exampleExecute,
-		Name:    "example",
+		Name:    "module:example",
 		Aliases: []string{"exp", "ex"},
 		UseFor:  "this is a description message",
 		// {$binName} {$cmd} is help vars. '{$cmd}' will replace to 'example'

--- a/app_run.go
+++ b/app_run.go
@@ -3,11 +3,12 @@ package gcli
 import (
 	"flag"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/gookit/color"
 	"github.com/gookit/gcli/helper"
 	"github.com/gookit/goutil/strutil"
-	"log"
-	"strings"
 )
 
 // parseGlobalOpts parse global options
@@ -222,8 +223,10 @@ var commandsHelp = `{{.Description}} (Version: <info>{{.Version}}</>)
   <info>-h, --help</>        Display the help information
   <info>-V, --version</>     Display app version information
 
-<comment>Available Commands:</>{{range .Cs}}{{if .Runnable}}
+<comment>Available Commands:</>{{range $module, $cs := .Cs}}
+<comment>{{$module}}</>{{range $cs}}
   <info>{{.Name | printf "%-12s"}}</> {{.UseFor}}{{if .Aliases}} (alias: <cyan>{{ join .Aliases ","}}</>){{end}}{{end}}{{end}}
+	
   <info>help</>         Display help information
 
 Use "<cyan>{$binName} {command} -h</>" for more information about a command
@@ -249,7 +252,7 @@ func (app *App) showCommandsHelp() {
 	commandsHelp = color.ReplaceTag(commandsHelp)
 	// render help text template
 	s := helper.RenderText(commandsHelp, map[string]interface{}{
-		"Cs": app.commands,
+		"Cs": app.moduleCommands,
 		// app version
 		"Version": app.Version,
 		// always upper first char

--- a/cmd.go
+++ b/cmd.go
@@ -3,8 +3,9 @@ package gcli
 import (
 	"flag"
 	"fmt"
-	"github.com/gookit/goutil/strutil"
 	"strings"
+
+	"github.com/gookit/goutil/strutil"
 )
 
 // Runner interface
@@ -31,6 +32,8 @@ type Command struct {
 
 	// Name is the command name.
 	Name string
+	// Module is the name for grouped commands
+	Module string
 	// UseFor is the command description message.
 	UseFor string
 	// Func is the command handler func. Func Runner


### PR DESCRIPTION
Available Commands:
 
  color        This is a example for cli color usage (alias: clr,colors)
  emoji        This is a emoji usage example command (alias: emoj)
**gen**
  gen:ac       Generate auto complete scripts for current application (alias: genac,gen-ac)
  gen:emojis   Fetch emoji codes form data source url, then generate a go file.
**module**
  module:env   Collect project info by git info (alias: env-info,ei)
  module:example This is a description message (alias: exp,ex)
	
  help         Display help information

