### PR TITLE
fix: panic when adding hooks to commands

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -747,6 +747,9 @@ func (c *Command) Fire(event string, data interface{}) (stop bool) {
 func (c *Command) On(name string, handler HookFunc) {
 	Debugf("cmd: %s - register hook: <cyan>%s</>", c.Name, name)
 
+	if c.Hooks == nil {
+		c.Hooks = &Hooks{}
+	}
 	c.Hooks.On(name, handler)
 }
 


### PR DESCRIPTION
Due to the lazy initialization of `Command`s, the underlying `core` and `Hooks` is not yet initialized, when the user tries to add hooks via `cmd.On(...)`. This PR ensures, that `Hooks` gets initialized once it is needed.