### PR TITLE
fix: nil pointer in serveman example

### DIFF
--- a/_examples/serveman/commands.go
+++ b/_examples/serveman/commands.go
@@ -23,7 +23,7 @@ type Config struct {
 }
 
 var (
-	config *Config
+	config = New(Config)
 	// config file
 	confFile string
 )


### PR DESCRIPTION

```
./serveman -h
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1201972]

...
```